### PR TITLE
Fix a syntax error in jdoom64/text.ded

### DIFF
--- a/doomsday/plugins/doom64/defs/text.ded
+++ b/doomsday/plugins/doom64/defs/text.ded
@@ -47,7 +47,7 @@ Text {
 
 Text {
   ID = "QLPROMPT";
-  Text = Really load the game in slot %s named\n\n'%s' ?";
+  Text = "Really load the game in slot %s named\n\n'%s' ?";
 }
 
 Text {


### PR DESCRIPTION
There existed a malformed string literal in `text.ded` on line 50 that would result in unclean termination during startup of the d64 game mode.