### PR TITLE
Force git to describe the revision at HEAD

### DIFF
--- a/doomsday/sdk/libcore/CMakeLists.txt
+++ b/doomsday/sdk/libcore/CMakeLists.txt
@@ -22,7 +22,7 @@ if (DEFINED DENG_BUILD)
 endif ()
 if (GIT_FOUND)
     execute_process (
-        COMMAND ${GIT_EXECUTABLE} describe --long 
+        COMMAND ${GIT_EXECUTABLE} describe --always --long 
         OUTPUT_VARIABLE DENG_GIT_DESCRIPTION 
         ERROR_QUIET
         OUTPUT_STRIP_TRAILING_WHITESPACE


### PR DESCRIPTION
`git describe --long` will only output revision information if there is something at HEAD, such as a tag. I added `--always` to this, which will result in it outputting information in the following format: `most_recent_tag-number_of_commit_ahead-commit_hash`.

An example of the output is this:

`cmake-build-1.15-155-gf44c7e5`.

If there is a tag at the current commit, it will just use that instead (like `git describe`)