### PR TITLE
Sort input file list

### DIFF
--- a/doomsday/build/scripts/packres.py
+++ b/doomsday/build/scripts/packres.py
@@ -46,7 +46,7 @@ class Pack:
                 # Write the contents of the folder recursively.
                 def process_dir(path, dest_path):
                     self.msg("processing %s" % os.path.normpath(path))
-                    for file in os.listdir(path):
+                    for file in sorted(os.listdir(path)):
                         real_file = os.path.join(path, file)
                         if file[0] == '.':
                             continue # Ignore these.


### PR DESCRIPTION
so that doomsday.pk3 builds in a reproducible way
in spite of indeterministic filesystem readdir order.

See https://reproducible-builds.org/ for why this is good.