### PR TITLE
Fix ambiguous `sem_t`

### DIFF
--- a/doomsday/libs/core/include/de/legacy/concurrency.h
+++ b/doomsday/libs/core/include/de/legacy/concurrency.h
@@ -31,7 +31,6 @@
 
 typedef void *thread_t;
 typedef void *mutex_t;
-typedef void *sem_t;
 
 typedef enum systhreadexitstatus_e {
     DE_THREAD_STOPPED_NORMALLY,


### PR DESCRIPTION
I encountered ambiguity between `typedef void *sem_t` and `sem_t` in semaphore.h when trying to build against libc++.

<details><summary>error message</summary>
<p>

```
In file included from /usr/include/semaphore.h:28,
                 from /libcxx-install-11/include/c++/v1/__threading_support:33,                                              from /libcxx-install-11/include/c++/v1/atomic:571,
                 from /libcxx-install-11/include/c++/v1/memory:681,
                 from /libcxx-install-11/include/c++/v1/algorithm:643,
                 from /usr/include/qt4/QtCore/qglobal.h:68,
                 from /usr/include/qt4/QtCore/qnamespace.h:45,
                 from /usr/include/qt4/QtCore/qobjectdefs.h:45,
                 from /usr/include/qt4/QtCore/qobject.h:47,
                 from /usr/include/qt4/QtCore/qthread.h:45,
                 from /usr/include/qt4/QtCore/QThread:1,
                 from include/de/concurrency.h:44,
                 from moc_concurrency.cpp:9:
/usr/include/x86_64-linux-gnu/bits/semaphore.h:40:3: error: conflicting declaration 'typedef union sem_t sem
_t'
 } sem_t;
   ^~~~~
In file included from moc_concurrency.cpp:9:
include/de/concurrency.h:33:15: note: previous declaration as 'typedef void* sem_t'
 typedef void *sem_t;
               ^~~~~
```

</p>
</details>

I searched around and found that there's no reference to this type; the compilation also works fine after deleting this definition. So I propose to delete this to support building against libc++.