### PR TITLE
Update the_Foundation branch name to origin/main

### DIFF
--- a/doomsday/build/scripts/build_deps.py
+++ b/doomsday/build/scripts/build_deps.py
@@ -43,7 +43,7 @@ for fmt in FORMATS:
 dependencies = [
     (
         'the_Foundation',
-        'https://git.skyjake.fi/skyjake/the_Foundation.git', 'origin/master',
+        'https://git.skyjake.fi/skyjake/the_Foundation.git', 'origin/main',
         [UNISTRING_DIR,
          '-DTFDN_ENABLE_DEBUG_OUTPUT=YES',
          '-DTFDN_ENABLE_TLSREQUEST=NO',


### PR DESCRIPTION
skyjake recently updated the_Foundation codebase organization; doomsday hasn't caught up (and no longer builds without this change).