### PR TITLE
Extend Image life span to avoid segfault

### DIFF
--- a/doomsday/apps/client/src/clientapp.cpp
+++ b/doomsday/apps/client/src/clientapp.cpp
@@ -626,7 +626,8 @@ ClientApp::ClientApp(const StringList &args)
     // Show the splash image in a separate window.
 #if !defined (DE_MSYS)
     {
-        SDL_Surface *splashSurface = createSDLSurfaceFromImage(Image::fromXpmData(doomsdaySplashXpm));
+        const Image splashImage = Image::fromXpmData(doomsdaySplashXpm);
+        SDL_Surface *splashSurface = createSDLSurfaceFromImage(splashImage);
 
         d->splashWindow =
             SDL_CreateWindow(DOOMSDAY_NICENAME,


### PR DESCRIPTION
Splash Image must exist when SDL_BlitSurface is called